### PR TITLE
fix: se añade comentario para semantic release de npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,4 @@ jobs:
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Se añade linea comentada, de manera que al momento de publicar el paquete de npm configurar el secrets npm para verificar el correcto funcionamiento del semantic release.