### PR TITLE
fix: docs readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ o
 <link rel="stylesheet" href="ruta/al/proyecto/dist/styles.css" />
 ```
 
+Si estas utilizando versiones anteriores de webpack, (Webpack 4 o inferiores), el prefijo ~ es necesario:
+
+```sh
+@import "~@gcba/obelisco-v2/dist/styles.css";
+
+```
+
 ### Tipografías
 
 Obelisco requiere las tipografías **Nunito** y **Open sans** disponibles en google fonts, para utilizarlas con su CDN podemos hacerlo de la siguiente forma:

--- a/app/src/documents/getting-started-module/ImportsModule.tsx
+++ b/app/src/documents/getting-started-module/ImportsModule.tsx
@@ -8,12 +8,15 @@ import MainDescription from '@/components/Template/MainDescription';
 import {
   BOOTSTRAP_CODE,
   BOXICONS_CODE,
+  BOXICONS_CODE_NPM,
+  MATERIAL_S_CODE_NPM,
   MATERIAL_SYMBOLS_CODE,
   NUNITO_CODE,
   OPENSANS_CODE,
   POPPER_CODE,
   STYLES_CODE,
   STYLES_CODE_CSS,
+  STYLES_CODE_CSS_WEBPACK4,
 } from './code-views';
 
 const ImportsModule: React.FC = () => {
@@ -41,6 +44,15 @@ const ImportsModule: React.FC = () => {
 
           <SyntaxHighlighter language="scss" style={dracula} wrapLongLines>
             {STYLES_CODE_CSS}
+          </SyntaxHighlighter>
+
+          <br />
+          <p>
+            Si estas utilizando versiones anteriores de webpack, (Webpack 4 o inferiores), el prefijo ~ es necesario:
+          </p>
+
+          <SyntaxHighlighter language="scss" style={dracula} wrapLongLines>
+            {STYLES_CODE_CSS_WEBPACK4}
           </SyntaxHighlighter>
         </div>
       ),
@@ -75,15 +87,17 @@ const ImportsModule: React.FC = () => {
         <div className="col-12">
           <h3 className="headline-lg">Boxicons: </h3>
           <SyntaxHighlighter language="bash" style={dracula} wrapLongLines>
-            {`npm install boxicons
- 
-// Es importante que incluyas el import a Boxicons en tu hoja de estilos si lo usas via NPM
-@import "material-symbols/index.css";
-`}
+            {BOXICONS_CODE_NPM}
           </SyntaxHighlighter>
 
           <br />
+          <p>Es importante que incluyas el import a Boxicons en tu hoja de estilos si lo usas via NPM</p>
 
+          <SyntaxHighlighter language="scss" style={dracula} wrapLongLines>
+            {`@import "boxicons/css/boxicons.min.css";`}
+          </SyntaxHighlighter>
+
+          <br />
           <h3 className="headline-lg">O puedes utilizar la CDN:</h3>
           <SyntaxHighlighter language="html" style={dracula} wrapLongLines>
             {BOXICONS_CODE}
@@ -93,11 +107,14 @@ const ImportsModule: React.FC = () => {
 
           <h3 className="headline-lg">Material Symbols:</h3>
           <SyntaxHighlighter language="bash" style={dracula} wrapLongLines>
-            {`npm install material-symbols@latest
- 
-// Es importante que incluyas el import a Material Symbols en tu hoja de estilos si lo usas via NPM
-@import "material-symbols/index.css";
-`}
+            {MATERIAL_S_CODE_NPM}
+          </SyntaxHighlighter>
+
+          <br />
+          <p>Es importante que incluyas el import a Material Symbols en tu hoja de estilos si lo usas via NPM</p>
+
+          <SyntaxHighlighter language="scss" style={dracula} wrapLongLines>
+            {`@import "material-symbols/index.css";`}
           </SyntaxHighlighter>
 
           <br />

--- a/app/src/documents/getting-started-module/InstallationModule.tsx
+++ b/app/src/documents/getting-started-module/InstallationModule.tsx
@@ -5,7 +5,7 @@ import { dracula } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import DocumentationTemplate from '@/components/Template/DocumentationTemplate';
 import MainDescription from '@/components/Template/MainDescription';
 
-import { CDN_CODE, NPM_CODE, PNPM_CODE, YARN_CODE } from './code-views';
+import { CDN_CODE, NPM_CODE, NPM_UPDATE_CODE, PNPM_CODE, YARN_CODE } from './code-views';
 
 const InstallationModule: React.FC = () => {
   const sections = [
@@ -46,7 +46,20 @@ const InstallationModule: React.FC = () => {
       ),
     },
     {
-      id: 'section-2',
+      id: 'section-3',
+      title: 'Actualización',
+      description:
+        'Si Obelisco V2 ya está instalado en el proyecto y necesitás actualizarlo a la última versión, en el directorio del proyecto hay que ejecutar:',
+      content: (
+        <div className="col-12">
+          <SyntaxHighlighter language="bash" style={dracula}>
+            {NPM_UPDATE_CODE}
+          </SyntaxHighlighter>
+        </div>
+      ),
+    },
+    {
+      id: 'section-4',
       title: 'Uso con CDN',
       description:
         'Si prefieres no instalar nada localmente, puedes incluir los estilos directamente desde nuestra CDN:',

--- a/app/src/documents/getting-started-module/code-views.ts
+++ b/app/src/documents/getting-started-module/code-views.ts
@@ -11,8 +11,11 @@ rel="stylesheet"
 export const OPENSANS_CODE = `<link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet" />`;
 export const STYLES_CODE = `<link rel="stylesheet" href="ruta/al/proyecto/dist/styles.css" />`;
 export const STYLES_CODE_CSS = `@import "@gcba/obelisco-v2/dist/styles.css";`;
+export const STYLES_CODE_CSS_WEBPACK4 = `@import "~@gcba/obelisco-v2/dist/styles.css";`;
 export const NUNITO_CODE = `<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@300;400;600;700&display=swap" rel="stylesheet" />`;
+export const BOXICONS_CODE_NPM = `npm install boxicons`;
 export const BOXICONS_CODE = `<link href="https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css" rel="stylesheet" />`;
+export const MATERIAL_S_CODE_NPM = `npm install material-symbols@latest`;
 export const MATERIAL_SYMBOLS_CODE = `<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,1,0"/>`;
 export const POPPER_CODE = `<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossOrigin="anonymous"></script>`;
 export const BOOTSTRAP_CODE = `<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js" integrity="sha384-0pUGZvbkm6XF6gxjEnlmuGrJXVbNuzT9qBBavbLwCsOGabYfZo0T0to5eqruptLy" crossOrigin="anonymous"></script>`;

--- a/app/src/documents/getting-started-module/code-views.ts
+++ b/app/src/documents/getting-started-module/code-views.ts
@@ -2,6 +2,7 @@
 export const NPM_CODE = `npm i @gcba/obelisco-v2`;
 export const YARN_CODE = `yarn add @gcba/obelisco-v2`;
 export const PNPM_CODE = `pnpm i @gcba/obelisco-v2`;
+export const NPM_UPDATE_CODE = `npm update @gcba/obelisco-v2`;
 export const CDN_CODE = `
 <link href="
 https://cdn.jsdelivr.net/gh/gcba/Obelisco-v2@main/dist/styles.css" 


### PR DESCRIPTION
Se añade informacion necesaria en el readme y en la seccion de instalacion e importacion del front de la libreria de obelisco v2.

Estas instrucciones detallan como importar los estilos de obelisco v2 en proyectos que utilizan webpack 4 o inferiores, tambien se añade el comando de actualizacion de obelisco v2 en proyectos que ya lo tienen instalado.

Se mejora la manera en que se muestran la indicaciones de importar los estilos de las librerias de iconos.