### PR TITLE
docs: cdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ npm update @gcba/obelisco-v2
 
 ```sh
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/gcba/Obelisco-v2@main/dist/styles.css" />
+<link href="https://cdn.jsdelivr.net/npm/@gcba/obelisco-v2@X.X.X/dist/styles.min.css" rel="stylesheet" />
 
 ```
+
+Si no instalás Obelisco de forma local, podés incluir los estilos directamente desde nuestra CDN. Sólo tenés que reemplazar la sección de la url en la que figura &quot;<code>X.X.X</code>&quot; por el número de la versión que desees utilizar. Te recomendamos usar la <a href="https://www.jsdelivr.com/package/npm/@gcba/obelisco-v2" target="_blank" rel="noopener noreferrer">versión más reciente</a>.
 
 ## Importación
 

--- a/app/src/documents/getting-started-module/InstallationModule.tsx
+++ b/app/src/documents/getting-started-module/InstallationModule.tsx
@@ -61,10 +61,21 @@ const InstallationModule: React.FC = () => {
     {
       id: 'section-4',
       title: 'Uso con CDN',
-      description:
-        'Si prefieres no instalar nada localmente, puedes incluir los estilos directamente desde nuestra CDN:',
       content: (
         <div className="col-12">
+          <p className="mb-4">
+            Si no instalás Obelisco de forma local, podés incluir los estilos directamente desde nuestra CDN. Sólo tenés
+            que reemplazar la sección de la url en la que figura &quot;<code>X.X.X</code>&quot; por el número de la
+            versión que desees utilizar. Te recomendamos usar la{' '}
+            <Link
+              href="https://www.jsdelivr.com/package/npm/@gcba/obelisco-v2"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              versión más reciente
+            </Link>
+            .
+          </p>
           <SyntaxHighlighter language="html" style={dracula}>
             {CDN_CODE}
           </SyntaxHighlighter>

--- a/app/src/documents/getting-started-module/code-views.ts
+++ b/app/src/documents/getting-started-module/code-views.ts
@@ -4,9 +4,9 @@ export const YARN_CODE = `yarn add @gcba/obelisco-v2`;
 export const PNPM_CODE = `pnpm i @gcba/obelisco-v2`;
 export const NPM_UPDATE_CODE = `npm update @gcba/obelisco-v2`;
 export const CDN_CODE = `
-<link href="
-https://cdn.jsdelivr.net/gh/gcba/Obelisco-v2@main/dist/styles.css" 
-rel="stylesheet" 
+<link 
+  href="https://cdn.jsdelivr.net/npm/@gcba/obelisco-v2@X.X.X/dist/styles.min.css" 
+  rel="stylesheet" 
 />`;
 // Section imports
 export const OPENSANS_CODE = `<link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet" />`;


### PR DESCRIPTION
Se reemplaza la cdn y se agrega información sobre [jsDelivr](https://www.jsdelivr.com/package/npm/@gcba/obelisco-v2)