### PR TITLE
fix: Ficha Colores Calendario, pesos tipograficos, gap entre botones Modal, img Header. Lint

### DIFF
--- a/app/src/documents/Badge/code-views.ts
+++ b/app/src/documents/Badge/code-views.ts
@@ -4,7 +4,8 @@ export const BADGE_COLORS = `<span class="badge badge-default">Predeterminada</s
 <span class="badge badge-success">Éxito</span>
 <span class="badge badge-warning">Advertencia</span>`;
 
-export const BADGE_TYPES = `<a href="#" class="badge badge-default">
+export const BADGE_TYPES = `// Default
+<a href="#" class="badge badge-default">
   ETIQUETA
 </a>
 <a href="#" class="badge badge-default hover">
@@ -12,4 +13,45 @@ export const BADGE_TYPES = `<a href="#" class="badge badge-default">
 </a>
 <a href="#" class="badge badge-default focus">
   ETIQUETA
-</a>`;
+</a>
+// Danger
+<a href="#" class="badge badge-danger">
+  ETIQUETA
+</a>
+<a href="#" class="badge badge-danger hover">
+  ETIQUETA
+</a>
+<a href="#" class="badge badge-danger focus">
+  ETIQUETA
+</a>
+// Info
+<a href="#" class="badge badge-info">
+  ETIQUETA
+</a>
+<a href="#" class="badge badge-info hover">
+  ETIQUETA
+</a>
+<a href="#" class="badge badge-info focus">
+  ETIQUETA
+</a>
+// Success
+<a href="#" class="badge badge-success">
+  ETIQUETA
+</a>
+<a href="#" class="badge badge-success hover">
+  ETIQUETA
+</a>
+<a href="#" class="badge badge-success focus">
+  ETIQUETA
+</a>
+// Warning
+<a href="#" class="badge badge-warning">
+  ETIQUETA
+</a>
+<a href="#" class="badge badge-warning hover">
+  ETIQUETA
+</a>
+<a href="#" class="badge badge-warning focus">
+  ETIQUETA
+</a>
+`;

--- a/app/src/documents/Button/ButtonDocs.tsx
+++ b/app/src/documents/Button/ButtonDocs.tsx
@@ -753,7 +753,7 @@ const ButtonDocs: React.FC = () => {
             <p className="text-md">
               Para contextos con acciones primarias y/o acciones principales. Normalmente, existe una única sección o
               agrupación de botones primarios por página. Por ejemplo, en el último paso de un formulario, antes de
-              enviar los datos, pueden haber 2 acciones: una para ver al detalle toda la información cargada, y una para
+              enviar los datos, puede haber 2 acciones: una para ver al detalle toda la información cargada, y una para
               enviar la información de manera definitiva; estas 2 acciones comparten el mismo nivel jerárquico, pero una
               tiene prioridad dentro de este nivel.
             </p>

--- a/app/src/documents/Colors/constants.ts
+++ b/app/src/documents/Colors/constants.ts
@@ -511,14 +511,15 @@ export const BUTTON_COLORS: ColorTableArray[] = [
 ];
 export const CALENDAR_COLORS: ColorTableArray[] = [
   {
-    base: '$bg-default',
-    hex: '#336ACC',
-    variable: 'bg-default',
+    base: '$bg-white',
+    hex: '#FFFFFF',
+    variable: '$bg-default',
     use: 'Es el color de fondo del calendario y las filas del calendario por defecto.',
+    customBorder: true,
   },
   {
     base: '$bg-secondary',
-    hex: '#2E569E',
+    hex: '#ECF0F9',
     variable: '$bg-secondary',
     use: 'Es el color de fondo secundario de las filas del calendario.',
   },

--- a/app/src/documents/Docs/Docs.tsx
+++ b/app/src/documents/Docs/Docs.tsx
@@ -9,11 +9,7 @@ const sections = [
     content: (
       <>
         <p className="mt-3">
-          Obelisco V2 se distingue de su predecesor por varias mejoras clave que optimizan tanto la funcionalidad
-          proporcionada por Bootstrap 5 como el rendimiento general del sistema. En esta nueva versión, hemos
-          implementado una serie de actualizaciones y refinamientos para ofrecer una experiencia de usuario superior y
-          una integración más eficiente. A continuación, se detallan algunas de las principales mejoras que diferencian
-          a Obelisco V2 de Obelisco V1:{' '}
+          Obelisco v2 mejora y actualiza los componentes y estilos ofrecidos en la versión anterior para diseñar interfaces consistentes, intuitivas y confiables en todos los productos digitales.
         </p>
       </>
     ),
@@ -23,9 +19,7 @@ const sections = [
     content: (
       <ul>
         <li>
-          <strong>Actualización a Bootstrap 5</strong>: A diferencia de &quot;Obelisco V1&quot;, que utilizaba Bootstrap
-          4, &quot;Obelisco V2&quot; ha migrado a Bootstrap 5. Esto permite aprovechar las nuevas funcionalidades,
-          mejoras de rendimiento y simplificaciones de código que vienen con la última versión de Bootstrap.
+          Con la nueva versión del framework dentro de Obelisco V2, mejora el rendimiento y la simplificación del código lo que permite aprovechar nuevas funcionalidades.
         </li>
       </ul>
     ),
@@ -34,9 +28,7 @@ const sections = [
     title: 'Optimización de código SCSS',
     content: (
       <li>
-        <strong>Optimización de código SCSS</strong>: Se han corregido variables y funciones presentes en el código SCSS
-        de &quot;Obelisco V1&quot;, mejorando así la calidad y la mantenibilidad del código. Además, se ha realizado una
-        limpieza de código para eliminar redundancias y optimizar la estructura de los estilos.
+        Se han corregido variables y funciones presentes en el código de Obelisco v1 mejorando la calidad y la minimización de errores, eliminando redundancias y optimizando la estructura de estilos.
       </li>
     ),
   },
@@ -44,28 +36,18 @@ const sections = [
     title: 'Eliminación de componentes deprecados',
     content: (
       <li>
-        <strong>Eliminación de componentes deprecados</strong>: En esta nueva versión, se han eliminado los componentes
-        que estaban deprecados o ya no eran necesarios, reduciendo así el peso y la complejidad de la librería.
+        En la nueva versión se han eliminado los componentes que ya no eran necesarios para así reducir el peso y complejidad de la librería.
       </li>
     ),
   },
   {
-    title: 'Incorporación de nuevas clases',
+    title: 'Integración de clases y refactorización de componentes',
     content: (
-      <li>
-        <strong>Incorporación de nuevas clases</strong>: Se han añadido nuevas clases, adaptadas a las nuevas
-        funcionalidades y estilos de Bootstrap 5.
-      </li>
-    ),
-  },
-  {
-    title: 'Refactorización de componentes',
-    content: (
-      <li>
-        <strong>Refactorización de componentes</strong>: Se han refactorizado componentes acorde a las nuevas
-        funcionalidades y estilos de Bootstrap 5, lo que permite a los desarrolladores aprovechar al máximo las nuevas
-        posibilidades que ofrece esta versión.
-      </li>
+      <>
+        <li>
+          Acorde a las nuevas funcionalidades y estilos de Bootstrap 5 y Obelisco, se añadieron nuevas clases dentro de la librería. Además, Se refactorizaron componentes, permitiendo aprovechar al máximo la nueva actualización de versión.
+        </li>
+      </>
     ),
   },
   {
@@ -73,9 +55,7 @@ const sections = [
     content: (
       <>
         <li>
-          <strong>Proceso de compilación y distribución</strong>: &quot;Obelisco V2&quot; incluye un proceso de buildeo
-          que compila los archivos SCSS a CSS. El resultado es un paquete optimizado de estilos CSS que puede ser
-          fácilmente integrado en cualquier proyecto.
+          Obelisco V2 incluye un proceso que compila archivos SCSS y da como resultado un paquete optimizado de estilos CSS que puede ser fácilmente integrado a cualquier proyecto.
         </li>
         <div className="col-12 col-lg-7 mt-4 ms-1">
           <Link href="/documentation/update-component" className="list-group-item item-sm">
@@ -116,7 +96,7 @@ const Docs: React.FC = () => {
       <ComponentHeader
         title="Documentación"
         description={[
-          'Esta nueva versión es una evolución de la versión anterior, "Obelisco V1", que busca mejorar y actualizar los componentes y estilos ofrecidos, alineándose con las últimas tendencias y estándares del desarrollo web.',
+          'Obelisco v2 mejora y actualiza los componentes y estilos ofrecidos en la versión anterior para diseñar interfaces consistentes, intuitivas y confiables en todos los productos digitales.',
         ]}
         divider={true}
       />

--- a/app/src/documents/Docs/Docs.tsx
+++ b/app/src/documents/Docs/Docs.tsx
@@ -9,8 +9,7 @@ const sections = [
     content: (
       <>
         <p className="mt-3">
-          Obelisco v2 mejora y actualiza los componentes y estilos ofrecidos en la versión anterior para diseñar
-          interfaces consistentes, intuitivas y confiables en todos los productos digitales.
+          Obelisco no es solo un sistema de diseño, es una <strong>herramienta estratégica y eficiente</strong>, que facilita la incorporación de nuevas tecnologías, entregando valor en ciclos más cortos mejorando la interacción con las personas usuarias.
         </p>
       </>
     ),
@@ -20,8 +19,8 @@ const sections = [
     content: (
       <ul>
         <li>
-          Con la nueva versión del framework dentro de Obelisco V2, mejora el rendimiento y la simplificación del código
-          lo que permite aprovechar nuevas funcionalidades.
+          Con la nueva versión del framework en Obelisco V2 mejora el rendimiento y la simplificación del código,
+          lo que permite aprovechar <strong>nuevas funcionalidades</strong>.
         </li>
       </ul>
     ),
@@ -50,7 +49,7 @@ const sections = [
       <>
         <li>
           Acorde a las nuevas funcionalidades y estilos de Bootstrap 5 y Obelisco, se añadieron nuevas clases dentro de
-          la librería. Además, Se refactorizaron componentes, permitiendo aprovechar al máximo la nueva actualización de
+          la librería. Además, Se refactorizaron componentes, permitiendo aprovechar al máximo la nueva actualización de la nueva 
           versión.
         </li>
       </>

--- a/app/src/documents/Docs/Docs.tsx
+++ b/app/src/documents/Docs/Docs.tsx
@@ -9,7 +9,9 @@ const sections = [
     content: (
       <>
         <p className="mt-3">
-          Obelisco no es solo un sistema de diseño, es una <strong>herramienta estratégica y eficiente</strong>, que facilita la incorporación de nuevas tecnologías, entregando valor en ciclos más cortos mejorando la interacción con las personas usuarias.
+          Obelisco no es solo un sistema de diseño, es una <strong>herramienta estratégica y eficiente</strong>, que
+          facilita la incorporación de nuevas tecnologías, entregando valor en ciclos más cortos mejorando la
+          interacción con las personas usuarias.
         </p>
       </>
     ),
@@ -19,8 +21,8 @@ const sections = [
     content: (
       <ul>
         <li>
-          Con la nueva versión del framework en Obelisco V2 mejora el rendimiento y la simplificación del código,
-          lo que permite aprovechar <strong>nuevas funcionalidades</strong>.
+          Con la nueva versión del framework en Obelisco V2 mejora el rendimiento y la simplificación del código, lo que
+          permite aprovechar <strong>nuevas funcionalidades</strong>.
         </li>
       </ul>
     ),
@@ -49,8 +51,8 @@ const sections = [
       <>
         <li>
           Acorde a las nuevas funcionalidades y estilos de Bootstrap 5 y Obelisco, se añadieron nuevas clases dentro de
-          la librería. Además, Se refactorizaron componentes, permitiendo aprovechar al máximo la nueva actualización de la nueva 
-          versión.
+          la librería. Además, Se refactorizaron componentes, permitiendo aprovechar al máximo la nueva actualización de
+          la nueva versión.
         </li>
       </>
     ),

--- a/app/src/documents/Docs/Docs.tsx
+++ b/app/src/documents/Docs/Docs.tsx
@@ -9,7 +9,8 @@ const sections = [
     content: (
       <>
         <p className="mt-3">
-          Obelisco v2 mejora y actualiza los componentes y estilos ofrecidos en la versión anterior para diseñar interfaces consistentes, intuitivas y confiables en todos los productos digitales.
+          Obelisco v2 mejora y actualiza los componentes y estilos ofrecidos en la versión anterior para diseñar
+          interfaces consistentes, intuitivas y confiables en todos los productos digitales.
         </p>
       </>
     ),
@@ -19,7 +20,8 @@ const sections = [
     content: (
       <ul>
         <li>
-          Con la nueva versión del framework dentro de Obelisco V2, mejora el rendimiento y la simplificación del código lo que permite aprovechar nuevas funcionalidades.
+          Con la nueva versión del framework dentro de Obelisco V2, mejora el rendimiento y la simplificación del código
+          lo que permite aprovechar nuevas funcionalidades.
         </li>
       </ul>
     ),
@@ -28,7 +30,8 @@ const sections = [
     title: 'Optimización de código SCSS',
     content: (
       <li>
-        Se han corregido variables y funciones presentes en el código de Obelisco v1 mejorando la calidad y la minimización de errores, eliminando redundancias y optimizando la estructura de estilos.
+        Se han corregido variables y funciones presentes en el código de Obelisco v1 mejorando la calidad y la
+        minimización de errores, eliminando redundancias y optimizando la estructura de estilos.
       </li>
     ),
   },
@@ -36,7 +39,8 @@ const sections = [
     title: 'Eliminación de componentes deprecados',
     content: (
       <li>
-        En la nueva versión se han eliminado los componentes que ya no eran necesarios para así reducir el peso y complejidad de la librería.
+        En la nueva versión se han eliminado los componentes que ya no eran necesarios para así reducir el peso y
+        complejidad de la librería.
       </li>
     ),
   },
@@ -45,7 +49,9 @@ const sections = [
     content: (
       <>
         <li>
-          Acorde a las nuevas funcionalidades y estilos de Bootstrap 5 y Obelisco, se añadieron nuevas clases dentro de la librería. Además, Se refactorizaron componentes, permitiendo aprovechar al máximo la nueva actualización de versión.
+          Acorde a las nuevas funcionalidades y estilos de Bootstrap 5 y Obelisco, se añadieron nuevas clases dentro de
+          la librería. Además, Se refactorizaron componentes, permitiendo aprovechar al máximo la nueva actualización de
+          versión.
         </li>
       </>
     ),
@@ -55,7 +61,8 @@ const sections = [
     content: (
       <>
         <li>
-          Obelisco V2 incluye un proceso que compila archivos SCSS y da como resultado un paquete optimizado de estilos CSS que puede ser fácilmente integrado a cualquier proyecto.
+          Obelisco V2 incluye un proceso que compila archivos SCSS y da como resultado un paquete optimizado de estilos
+          CSS que puede ser fácilmente integrado a cualquier proyecto.
         </li>
         <div className="col-12 col-lg-7 mt-4 ms-1">
           <Link href="/documentation/update-component" className="list-group-item item-sm">

--- a/app/src/documents/Header/HeaderDocs.tsx
+++ b/app/src/documents/Header/HeaderDocs.tsx
@@ -2176,7 +2176,7 @@ const HeaderDocs: React.FC = () => {
             <div className="max-items-2">
               <div className="col">
                 <Image
-                  src={`${basePath}/images/header/header_Columnas_si_usar.svg`}
+                  src={`${basePath}/images/header/header_columnas_si_usar.svg`}
                   alt="Cómo usar la navegacion principal de header"
                   width="800"
                   height="352"
@@ -2191,7 +2191,7 @@ const HeaderDocs: React.FC = () => {
               </div>
               <div className="col">
                 <Image
-                  src={`${basePath}/images/header/header_Columnas_no_usar.svg`}
+                  src={`${basePath}/images/header/header_columnas_no_usar.svg`}
                   alt="Cómo usar la navegacion principal de header"
                   width="800"
                   height="352"

--- a/app/src/documents/Highlighted/HighlightedDocs.tsx
+++ b/app/src/documents/Highlighted/HighlightedDocs.tsx
@@ -310,9 +310,9 @@ const HighlightedDocs: React.FC = () => {
                       <div className="panel-body">
                         <h2 className="panel-title">Título del destacado</h2>
                         <p className="panel-text">
-                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                          líneas. No puede contener negritas ni enlaces
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede
+                          contener negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de
+                          pocas líneas. No puede contener negritas ni enlaces
                         </p>
                         <div className="panel-footer">
                           <LinkClient className="btn btn-primary btn-lg">Botón</LinkClient>
@@ -332,9 +332,9 @@ const HighlightedDocs: React.FC = () => {
                       <div className="panel-body">
                         <h2 className="panel-title">Título del destacado</h2>
                         <p className="panel-text">
-                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                          líneas. No puede contener negritas ni enlaces
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede
+                          contener negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de
+                          pocas líneas. No puede contener negritas ni enlaces
                         </p>
                         <div className="panel-footer">
                           <LinkClient className="btn btn-secondary btn-lg" download="">
@@ -359,9 +359,9 @@ const HighlightedDocs: React.FC = () => {
                       <div className="panel-body">
                         <h2 className="panel-title">Título del destacado</h2>
                         <p className="panel-text">
-                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                          líneas. No puede contener negritas ni enlaces
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede
+                          contener negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de
+                          pocas líneas. No puede contener negritas ni enlaces
                         </p>
                         <div className="panel-footer">
                           <LinkClient className="external">Enlace externo</LinkClient>
@@ -381,9 +381,9 @@ const HighlightedDocs: React.FC = () => {
                       <div className="panel-body">
                         <h2 className="panel-title">Título del destacado</h2>
                         <p className="panel-text">
-                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                          líneas. No puede contener negritas ni enlaces
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede
+                          contener negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de
+                          pocas líneas. No puede contener negritas ni enlaces
                         </p>
                         <div className="panel-footer">
                           <LinkClient className="list-group-item item-sm">
@@ -421,9 +421,9 @@ const HighlightedDocs: React.FC = () => {
                       <div className="panel-body">
                         <h2 className="panel-title">Título del destacado</h2>
                         <p className="panel-text">
-                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                          líneas. No puede contener negritas ni enlaces
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede
+                          contener negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de
+                          pocas líneas. No puede contener negritas ni enlaces
                         </p>
                         <div className="panel-footer">
                           <LinkClient className="btn btn-primary btn-lg">Botón</LinkClient>
@@ -444,9 +444,9 @@ const HighlightedDocs: React.FC = () => {
                       <div className="panel-body">
                         <h2 className="panel-title">Título del destacado</h2>
                         <p className="panel-text">
-                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                          líneas. No puede contener negritas ni enlaces
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede
+                          contener negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de
+                          pocas líneas. No puede contener negritas ni enlaces
                         </p>
                         <div className="panel-footer">
                           <LinkClient className="btn btn-primary btn-lg">Botón</LinkClient>
@@ -468,9 +468,9 @@ const HighlightedDocs: React.FC = () => {
                       <div className="panel-body">
                         <h2 className="panel-title">Título del destacado</h2>
                         <p className="panel-text">
-                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                          líneas. No puede contener negritas ni enlaces
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede
+                          contener negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de
+                          pocas líneas. No puede contener negritas ni enlaces
                         </p>
                         <div className="panel-footer">
                           <LinkClient className="btn btn-primary btn-lg">Botón</LinkClient>
@@ -483,9 +483,9 @@ const HighlightedDocs: React.FC = () => {
                       <div className="panel-body">
                         <h2 className="panel-title">Título del destacado</h2>
                         <p className="panel-text">
-                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                          líneas. No puede contener negritas ni enlaces
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede
+                          contener negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de
+                          pocas líneas. No puede contener negritas ni enlaces
                         </p>
                         <div className="panel-footer">
                           <LinkClient className="btn btn-secondary btn-lg" download="">
@@ -503,9 +503,9 @@ const HighlightedDocs: React.FC = () => {
                       <div className="panel-body">
                         <h2 className="panel-title">Título del destacado</h2>
                         <p className="panel-text">
-                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                          líneas. No puede contener negritas ni enlaces
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede
+                          contener negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de
+                          pocas líneas. No puede contener negritas ni enlaces
                         </p>
                         <div className="panel-footer">
                           <LinkClient className="external">Enlace externo</LinkClient>
@@ -518,9 +518,9 @@ const HighlightedDocs: React.FC = () => {
                       <div className="panel-body">
                         <h2 className="panel-title">Título del destacado</h2>
                         <p className="panel-text">
-                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                          líneas. No puede contener negritas ni enlaces
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede
+                          contener negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de
+                          pocas líneas. No puede contener negritas ni enlaces
                         </p>
                         <div className="panel-footer">
                           <LinkClient className="list-group-item item-sm">
@@ -540,7 +540,7 @@ const HighlightedDocs: React.FC = () => {
             </div>
           </CodeBox>
         </>
-      )
+      ),
     },
     {
       title: 'Destacado lateral',

--- a/app/src/documents/Highlighted/HighlightedDocs.tsx
+++ b/app/src/documents/Highlighted/HighlightedDocs.tsx
@@ -29,10 +29,7 @@ const basePath = '/Obelisco-V2';
 const HighlightedDocs: React.FC = () => {
   const SECTIONS_DEV = [
     {
-      title: 'Banner',
-    },
-    {
-      subtitle: 'Con imagen',
+      title: 'Destacado banner',
       content: (
         <>
           <CodeBox codeHTML={HIGHLIGHTED_BANNER_BUTTONS}>
@@ -182,13 +179,7 @@ const HighlightedDocs: React.FC = () => {
               </div>
             </div>
           </CodeBox>
-        </>
-      ),
-    },
-    {
-      subtitle: 'Con video',
-      content: (
-        <>
+          <br />
           <CodeBox codeHTML={HIGHLIGHTED_BANNER_BUTTONS_VIDEO_MP4}>
             <div className="highlighted-box-sizing">
               <div className="panel-horizontal-content">
@@ -247,13 +238,7 @@ const HighlightedDocs: React.FC = () => {
               </div>
             </div>
           </CodeBox>
-        </>
-      ),
-    },
-    {
-      subtitle: 'Sin multimedia',
-      content: (
-        <>
+          <br />
           <CodeBox codeHTML={HIGHLIGHTED_BANNER_NO_MEDIA}>
             <div className="highlighted-box-sizing">
               <div className="panel-horizontal-content">
@@ -274,13 +259,7 @@ const HighlightedDocs: React.FC = () => {
               </div>
             </div>
           </CodeBox>
-        </>
-      ),
-    },
-    {
-      subtitle: 'Con fondo',
-      content: (
-        <>
+          <br />
           <CodeBox codeHTML={HIGHLIGHTED_BANNER_BUTTONS_BG}>
             <div className="highlighted-box-sizing">
               <div className="panel-horizontal-content bg-light">
@@ -312,268 +291,259 @@ const HighlightedDocs: React.FC = () => {
       ),
     },
     {
-      title: 'Conjunto',
-    },
-    {
-      subtitle: 'Con imagen',
+      title: 'Destacado conjunto',
       content: (
-        <CodeBox codeHTML={HIGHLIGHTED_JOIN_IMAGE}>
-          <div className="highlighted-box-sizing-vertical">
-            <div className="container">
-              <div className="highlighted-items-2">
-                <div className="col">
-                  <div className="panel-vertical">
-                    <Image
-                      src={`${basePath}/images/destacado.jpg`}
-                      alt="descripción de imagen"
-                      className="panel-img"
-                      width={538}
-                      height={304}
-                    ></Image>
-                    <div className="panel-body">
-                      <h2 className="panel-title">Título del destacado</h2>
-                      <p className="panel-text">
-                        Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                        negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                        líneas. No puede contener negritas ni enlaces
-                      </p>
-                      <div className="panel-footer">
-                        <LinkClient className="btn btn-primary btn-lg">Botón</LinkClient>
+        <>
+          <CodeBox codeHTML={HIGHLIGHTED_JOIN_IMAGE}>
+            <div className="highlighted-box-sizing-vertical">
+              <div className="container">
+                <div className="highlighted-items-2">
+                  <div className="col">
+                    <div className="panel-vertical">
+                      <Image
+                        src={`${basePath}/images/destacado.jpg`}
+                        alt="descripción de imagen"
+                        className="panel-img"
+                        width={538}
+                        height={304}
+                      ></Image>
+                      <div className="panel-body">
+                        <h2 className="panel-title">Título del destacado</h2>
+                        <p className="panel-text">
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
+                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
+                          líneas. No puede contener negritas ni enlaces
+                        </p>
+                        <div className="panel-footer">
+                          <LinkClient className="btn btn-primary btn-lg">Botón</LinkClient>
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
-                <div className="col">
-                  <div className="panel-vertical">
-                    <Image
-                      src={`${basePath}/images/destacado.jpg`}
-                      alt="descripción de imagen"
-                      className="panel-img"
-                      width={538}
-                      height={304}
-                    ></Image>
-                    <div className="panel-body">
-                      <h2 className="panel-title">Título del destacado</h2>
-                      <p className="panel-text">
-                        Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                        negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                        líneas. No puede contener negritas ni enlaces
-                      </p>
-                      <div className="panel-footer">
-                        <LinkClient className="btn btn-secondary btn-lg" download="">
-                          <span className="material-symbols-rounded" aria-hidden="true">
-                            file_download
-                          </span>
-                          Descargar
-                        </LinkClient>
+                  <div className="col">
+                    <div className="panel-vertical">
+                      <Image
+                        src={`${basePath}/images/destacado.jpg`}
+                        alt="descripción de imagen"
+                        className="panel-img"
+                        width={538}
+                        height={304}
+                      ></Image>
+                      <div className="panel-body">
+                        <h2 className="panel-title">Título del destacado</h2>
+                        <p className="panel-text">
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
+                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
+                          líneas. No puede contener negritas ni enlaces
+                        </p>
+                        <div className="panel-footer">
+                          <LinkClient className="btn btn-secondary btn-lg" download="">
+                            <span className="material-symbols-rounded" aria-hidden="true">
+                              file_download
+                            </span>
+                            Descargar
+                          </LinkClient>
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
-                <div className="col">
-                  <div className="panel-vertical">
-                    <Image
-                      src={`${basePath}/images/destacado.jpg`}
-                      alt="descripción de imagen"
-                      className="panel-img"
-                      width={538}
-                      height={304}
-                    ></Image>
-                    <div className="panel-body">
-                      <h2 className="panel-title">Título del destacado</h2>
-                      <p className="panel-text">
-                        Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                        negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                        líneas. No puede contener negritas ni enlaces
-                      </p>
-                      <div className="panel-footer">
-                        <LinkClient className="external">Enlace externo</LinkClient>
+                  <div className="col">
+                    <div className="panel-vertical">
+                      <Image
+                        src={`${basePath}/images/destacado.jpg`}
+                        alt="descripción de imagen"
+                        className="panel-img"
+                        width={538}
+                        height={304}
+                      ></Image>
+                      <div className="panel-body">
+                        <h2 className="panel-title">Título del destacado</h2>
+                        <p className="panel-text">
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
+                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
+                          líneas. No puede contener negritas ni enlaces
+                        </p>
+                        <div className="panel-footer">
+                          <LinkClient className="external">Enlace externo</LinkClient>
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
-                <div className="col">
-                  <div className="panel-vertical">
-                    <Image
-                      src={`${basePath}/images/destacado.jpg`}
-                      alt="descripción de imagen"
-                      className="panel-img"
-                      width={538}
-                      height={304}
-                    ></Image>
-                    <div className="panel-body">
-                      <h2 className="panel-title">Título del destacado</h2>
-                      <p className="panel-text">
-                        Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                        negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                        líneas. No puede contener negritas ni enlaces
-                      </p>
-                      <div className="panel-footer">
-                        <LinkClient className="list-group-item item-sm">
-                          <span className="material-symbols-rounded o-icon" aria-hidden="true">
-                            info
-                          </span>
-                          <div className="access-content">
-                            <span className="access-title">Acceso</span>
-                          </div>
-                        </LinkClient>
+                  <div className="col">
+                    <div className="panel-vertical">
+                      <Image
+                        src={`${basePath}/images/destacado.jpg`}
+                        alt="descripción de imagen"
+                        className="panel-img"
+                        width={538}
+                        height={304}
+                      ></Image>
+                      <div className="panel-body">
+                        <h2 className="panel-title">Título del destacado</h2>
+                        <p className="panel-text">
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
+                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
+                          líneas. No puede contener negritas ni enlaces
+                        </p>
+                        <div className="panel-footer">
+                          <LinkClient className="list-group-item item-sm">
+                            <span className="material-symbols-rounded o-icon" aria-hidden="true">
+                              info
+                            </span>
+                            <div className="access-content">
+                              <span className="access-title">Acceso</span>
+                            </div>
+                          </LinkClient>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-        </CodeBox>
-      ),
-    },
-    {
-      subtitle: 'Con video',
-      content: (
-        <CodeBox codeHTML={HIGHLIGHTED_JOIN_VIDEO}>
-          <div className="highlighted-box-sizing-vertical max-h-800">
-            <div className="container">
-              <div className="highlighted-items-2">
-                <div className="col">
-                  <div className="panel-vertical">
-                    <p className="sr-only">Buenos Aires se escribe en plural</p>
-                    <video className="panel-img" controls>
-                      <source src={`${basePath}/images/videoBuenosAires.mp4`} type="video/mp4" />
-                      <track src={`${basePath}/images/videoBuenosAires.vtt`} default kind="captions" srcLang="es" />
-                      <p>
-                        Su navegador no soporta vídeos HTML5. Puedes ver el video haciendo clic en
-                        <a href={`${basePath}/images/videoBuenosAires.mp4`}>este enlace</a>.
-                      </p>
-                    </video>
-                    <div className="panel-body">
-                      <h2 className="panel-title">Título del destacado</h2>
-                      <p className="panel-text">
-                        Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                        negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                        líneas. No puede contener negritas ni enlaces
-                      </p>
-                      <div className="panel-footer">
-                        <LinkClient className="btn btn-primary btn-lg">Botón</LinkClient>
+          </CodeBox>
+          <br />
+          <CodeBox codeHTML={HIGHLIGHTED_JOIN_VIDEO}>
+            <div className="highlighted-box-sizing-vertical max-h-800">
+              <div className="container">
+                <div className="highlighted-items-2">
+                  <div className="col">
+                    <div className="panel-vertical">
+                      <p className="sr-only">Buenos Aires se escribe en plural</p>
+                      <video className="panel-img" controls>
+                        <source src={`${basePath}/images/videoBuenosAires.mp4`} type="video/mp4" />
+                        <track src={`${basePath}/images/videoBuenosAires.vtt`} default kind="captions" srcLang="es" />
+                        <p>
+                          Su navegador no soporta vídeos HTML5. Puedes ver el video haciendo clic en
+                          <a href={`${basePath}/images/videoBuenosAires.mp4`}>este enlace</a>.
+                        </p>
+                      </video>
+                      <div className="panel-body">
+                        <h2 className="panel-title">Título del destacado</h2>
+                        <p className="panel-text">
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
+                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
+                          líneas. No puede contener negritas ni enlaces
+                        </p>
+                        <div className="panel-footer">
+                          <LinkClient className="btn btn-primary btn-lg">Botón</LinkClient>
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
-                <div className="col">
-                  <div className="panel-vertical">
-                    <iframe
-                      className="panel-img"
-                      src="https://www.youtube.com/embed/sXE613Oaxvc?si=iWSX1erqQxXOLojw"
-                      title="Buenos Aires se escribe en plural"
-                      frameBorder={0}
-                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                      allowFullScreen
-                    ></iframe>
-                    <div className="panel-body">
-                      <h2 className="panel-title">Título del destacado</h2>
-                      <p className="panel-text">
-                        Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                        negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                        líneas. No puede contener negritas ni enlaces
-                      </p>
-                      <div className="panel-footer">
-                        <LinkClient className="btn btn-primary btn-lg">Botón</LinkClient>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </CodeBox>
-      ),
-    },
-    {
-      subtitle: 'Sin multimedia',
-      content: (
-        <CodeBox codeHTML={HIGHLIGHTED_JOIN_NO_IMAGE}>
-          <div className="highlighted-box-sizing-vertical max-h-640">
-            <div className="container">
-              <div className="highlighted-items-2">
-                <div className="col">
-                  <div className="panel-vertical">
-                    <div className="panel-body">
-                      <h2 className="panel-title">Título del destacado</h2>
-                      <p className="panel-text">
-                        Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                        negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                        líneas. No puede contener negritas ni enlaces
-                      </p>
-                      <div className="panel-footer">
-                        <LinkClient className="btn btn-primary btn-lg">Botón</LinkClient>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div className="col">
-                  <div className="panel-vertical">
-                    <div className="panel-body">
-                      <h2 className="panel-title">Título del destacado</h2>
-                      <p className="panel-text">
-                        Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                        negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                        líneas. No puede contener negritas ni enlaces
-                      </p>
-                      <div className="panel-footer">
-                        <LinkClient className="btn btn-secondary btn-lg" download="">
-                          <span className="material-symbols-rounded" aria-hidden="true">
-                            file_download
-                          </span>
-                          Descargar
-                        </LinkClient>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div className="col">
-                  <div className="panel-vertical">
-                    <div className="panel-body">
-                      <h2 className="panel-title">Título del destacado</h2>
-                      <p className="panel-text">
-                        Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                        negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                        líneas. No puede contener negritas ni enlaces
-                      </p>
-                      <div className="panel-footer">
-                        <LinkClient className="external">Enlace externo</LinkClient>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div className="col">
-                  <div className="panel-vertical">
-                    <div className="panel-body">
-                      <h2 className="panel-title">Título del destacado</h2>
-                      <p className="panel-text">
-                        Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
-                        negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
-                        líneas. No puede contener negritas ni enlaces
-                      </p>
-                      <div className="panel-footer">
-                        <LinkClient className="list-group-item item-sm">
-                          <span className="material-symbols-rounded o-icon" aria-hidden="true">
-                            info
-                          </span>
-                          <div className="access-content">
-                            <span className="access-title">Acceso</span>
-                          </div>
-                        </LinkClient>
+                  <div className="col">
+                    <div className="panel-vertical">
+                      <iframe
+                        className="panel-img"
+                        src="https://www.youtube.com/embed/sXE613Oaxvc?si=iWSX1erqQxXOLojw"
+                        title="Buenos Aires se escribe en plural"
+                        frameBorder={0}
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                        allowFullScreen
+                      ></iframe>
+                      <div className="panel-body">
+                        <h2 className="panel-title">Título del destacado</h2>
+                        <p className="panel-text">
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
+                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
+                          líneas. No puede contener negritas ni enlaces
+                        </p>
+                        <div className="panel-footer">
+                          <LinkClient className="btn btn-primary btn-lg">Botón</LinkClient>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-        </CodeBox>
-      ),
+          </CodeBox>
+          <br />
+          <CodeBox codeHTML={HIGHLIGHTED_JOIN_NO_IMAGE}>
+            <div className="highlighted-box-sizing-vertical max-h-640">
+              <div className="container">
+                <div className="highlighted-items-2">
+                  <div className="col">
+                    <div className="panel-vertical">
+                      <div className="panel-body">
+                        <h2 className="panel-title">Título del destacado</h2>
+                        <p className="panel-text">
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
+                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
+                          líneas. No puede contener negritas ni enlaces
+                        </p>
+                        <div className="panel-footer">
+                          <LinkClient className="btn btn-primary btn-lg">Botón</LinkClient>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="col">
+                    <div className="panel-vertical">
+                      <div className="panel-body">
+                        <h2 className="panel-title">Título del destacado</h2>
+                        <p className="panel-text">
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
+                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
+                          líneas. No puede contener negritas ni enlaces
+                        </p>
+                        <div className="panel-footer">
+                          <LinkClient className="btn btn-secondary btn-lg" download="">
+                            <span className="material-symbols-rounded" aria-hidden="true">
+                              file_download
+                            </span>
+                            Descargar
+                          </LinkClient>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="col">
+                    <div className="panel-vertical">
+                      <div className="panel-body">
+                        <h2 className="panel-title">Título del destacado</h2>
+                        <p className="panel-text">
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
+                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
+                          líneas. No puede contener negritas ni enlaces
+                        </p>
+                        <div className="panel-footer">
+                          <LinkClient className="external">Enlace externo</LinkClient>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="col">
+                    <div className="panel-vertical">
+                      <div className="panel-body">
+                        <h2 className="panel-title">Título del destacado</h2>
+                        <p className="panel-text">
+                          Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas líneas. No puede contener
+                          negritas ni enlaces. Este es el cuerpo de un destacado. Debe ser breve y conciso, de pocas
+                          líneas. No puede contener negritas ni enlaces
+                        </p>
+                        <div className="panel-footer">
+                          <LinkClient className="list-group-item item-sm">
+                            <span className="material-symbols-rounded o-icon" aria-hidden="true">
+                              info
+                            </span>
+                            <div className="access-content">
+                              <span className="access-title">Acceso</span>
+                            </div>
+                          </LinkClient>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </CodeBox>
+        </>
+      )
     },
     {
-      title: 'Lateral',
+      title: 'Destacado lateral',
       content: (
         <>
           <CodeBox codeHTML={HIGHLIGHTED_LATERAL_BUTTON}>

--- a/app/src/documents/Typography/TypographyDocs.tsx
+++ b/app/src/documents/Typography/TypographyDocs.tsx
@@ -220,8 +220,23 @@ const SECTIONS_UX = [
         </p>
         <p className="mb-4">
           Dentro de nuestra escala tipográfica utilizamos <i>regular</i>, <i>semibold</i> y <i>bold</i> como los únicos
-          pesos con los que pueden trabajar dentro de Obelisco.
+          pesos con los que pueden trabajar dentro de Obelisco.{' '}
+          <strong>Cada uno de los tamaños de la escala tiene un peso predeterminado:</strong>
         </p>
+
+        <ul className="list-informative-bullet mb-4">
+          <li>
+            Los tamaños de Cuerpo <i>(Body)</i> utilizan <i>regular</i> como peso predeterminado.
+          </li>
+          <li>
+            Los tamaños de Titulares <i>(Titles)</i>, Titulares/M y Titulares/S, utilizan <i>semibold</i> como peso
+            predeterminado, mientras que los Titulares/L utilizan <i>bold</i> como peso predeterminado.
+          </li>
+          <li>
+            Todos los <i>H’s</i> utilizan <i>semibold</i> como peso predeterminado, excepto por los H1, que utilizan{' '}
+            <i>bold</i> como peso predeterminado.
+          </li>
+        </ul>
 
         <div className="d-flex flex-column flex-md-row align-items-center mb-4" style={{ gap: '32px' }}>
           <img src={`${basePath}/images/typography/typography_5.svg`} alt="Texto en negrita" />

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -83,7 +83,7 @@ $modal-mobile: 328px;
     .modal-footer {
       border-top: 0;
       padding: 1rem 0 0;
-      gap: 0.5rem;
+      gap: 0.75rem;
 
       button.btn {
         margin: 0;


### PR DESCRIPTION
- Se corrige la ruta de las imagenes del Header

- Se corrige la ficha de Color del Organismo Calendario, quedó así:
![image](https://github.com/user-attachments/assets/b0838556-9fb2-4431-9907-668f27bfdf7e)

- Ficha de Tipografia | Pesos Tipograficos, quedó así::
![image](https://github.com/user-attachments/assets/8f8f840d-6614-42a7-8bef-fee3e53d8c28)

- Gap de 8px a 12px entre los botones del modal

- Fix en code view de Badge y correción en contenido de Button (1 letra)

- Scrollspy de Destacado

- Wording en Obelisco-V2/documentation

Figma: 
https://www.figma.com/design/ysBh7PNXf9HYfrrlMsvMmn/Fichas---Obelisco-V2?node-id=6-6881&m=dev
https://www.figma.com/design/ysBh7PNXf9HYfrrlMsvMmn/Fichas---Obelisco-V2?node-id=6-10152&m=dev