### PR TITLE
fix: Peso de h5 a semibold, correción de texto en Redactar Noticia

### DIFF
--- a/app/src/documents/Contenidos/RedactarNoticiaDocs.tsx
+++ b/app/src/documents/Contenidos/RedactarNoticiaDocs.tsx
@@ -14,7 +14,7 @@ const sections = [
 
         <ul className="list-informative-bullet">
           <li className="mb-3">
-            Longitud: entre <strong>50 y 70 caracteres</strong> (ideal para buscadores y redes sociales).
+            Longitud recomendada: entre <strong>50 y 70 caracteres</strong> (ideal para buscadores y redes sociales).
           </li>
           <li>Evitar siglas poco conocidas y jerga técnica.</li>
         </ul>

--- a/app/src/documents/Table/TableDocs.tsx
+++ b/app/src/documents/Table/TableDocs.tsx
@@ -31,10 +31,12 @@ const SECTIONS_DEV = [
       <>
         <CodeBox codeHTML={WITHOUT_DIVIDERS}>
           <div className="max-600 p-2">
-            <h2>Título de tabla</h2>
-            <p className="text-md mt-3">
-              Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
-            </p>
+            <div className="table-title">
+              <h2 className="mb-4">Título de tabla</h2>
+              <p className="text-md">
+                Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+              </p>
+            </div>
             <div className="responsive-scroll" tabIndex={0}>
               <table className="table table-borderless">
                 <thead>
@@ -192,6 +194,12 @@ const SECTIONS_DEV = [
     content: (
       <CodeBox codeHTML={WITH_DIVIDERS}>
         <div className="max-600 p-2">
+          <div className="table-title">
+            <h2 className="mb-4">Título de tabla</h2>
+            <p className="text-md">
+              Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+            </p>
+          </div>
           <div className="responsive-scroll" tabIndex={0}>
             <table className="table">
               <thead>
@@ -345,6 +353,12 @@ const SECTIONS_DEV = [
     content: (
       <CodeBox codeHTML={WITH_ZEBRA}>
         <div className="max-600 p-2">
+          <div className="table-title">
+            <h2 className="mb-4">Título de tabla</h2>
+            <p className="text-md">
+              Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+            </p>
+          </div>
           <div className="responsive-scroll" tabIndex={0}>
             <table className="table table-striped">
               <thead>
@@ -498,6 +512,12 @@ const SECTIONS_DEV = [
     content: (
       <CodeBox codeHTML={WITH_CHECKBOX}>
         <div className="max-600 p-2">
+          <div className="table-title">
+            <h2 className="mb-4">Título de tabla</h2>
+            <p className="text-md">
+              Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+            </p>
+          </div>
           <div className="responsive-scroll" tabIndex={0}>
             <table className="table">
               <thead>
@@ -623,6 +643,12 @@ const SECTIONS_DEV = [
     content: (
       <CodeBox codeHTML={TABLE_TEXT}>
         <div className="max-600 p-2">
+          <div className="table-title">
+            <h2 className="mb-4">Título de tabla</h2>
+            <p className="text-md">
+              Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+            </p>
+          </div>
           <div className="responsive-scroll" tabIndex={0}>
             <table className="table">
               <thead>
@@ -671,6 +697,12 @@ const SECTIONS_DEV = [
     content: (
       <CodeBox codeHTML={TABLE_NUMBER}>
         <div className="max-600 p-2">
+          <div className="table-title">
+            <h2 className="mb-4">Título de tabla</h2>
+            <p className="text-md">
+              Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+            </p>
+          </div>
           <div className="responsive-scroll" tabIndex={0}>
             <table className="table">
               <thead>
@@ -736,6 +768,12 @@ const SECTIONS_DEV = [
     content: (
       <CodeBox codeHTML={TABLE_LINK}>
         <div className="max-600 p-2">
+          <div className="table-title">
+            <h2 className="mb-4">Título de tabla</h2>
+            <p className="text-md">
+              Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+            </p>
+          </div>
           <div className="responsive-scroll" tabIndex={0}>
             <table className="table">
               <thead>
@@ -809,6 +847,12 @@ const SECTIONS_DEV = [
     content: (
       <CodeBox codeHTML={TABLE_TAG}>
         <div className="max-600 p-2">
+          <div className="table-title">
+            <h2 className="mb-4">Título de tabla</h2>
+            <p className="text-md">
+              Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+            </p>
+          </div>
           <div className="responsive-scroll" tabIndex={0}>
             <table className="table">
               <thead>
@@ -882,6 +926,12 @@ const SECTIONS_DEV = [
     content: (
       <CodeBox codeHTML={TABLE_BUTTON}>
         <div className="max-600 p-2">
+          <div className="table-title">
+            <h2 className="mb-4">Título de tabla</h2>
+            <p className="text-md">
+              Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+            </p>
+          </div>
           <div className="responsive-scroll" tabIndex={0}>
             <table className="table">
               <thead>
@@ -963,6 +1013,12 @@ const SECTIONS_DEV = [
     content: (
       <CodeBox codeHTML={TABLE_BUTTON_ICON}>
         <div className="max-600 p-2">
+          <div className="table-title">
+            <h2 className="mb-4">Título de tabla</h2>
+            <p className="text-md">
+              Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+            </p>
+          </div>
           <div className="responsive-scroll" tabIndex={0}>
             <table className="table">
               <thead>

--- a/app/src/documents/Table/TableDocs.tsx
+++ b/app/src/documents/Table/TableDocs.tsx
@@ -31,6 +31,10 @@ const SECTIONS_DEV = [
       <>
         <CodeBox codeHTML={WITHOUT_DIVIDERS}>
           <div className="max-600 p-2">
+            <h2>Título de tabla</h2>
+            <p className="text-md mt-3">
+              Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+            </p>
             <div className="responsive-scroll" tabIndex={0}>
               <table className="table table-borderless">
                 <thead>

--- a/app/src/documents/Table/code-views.ts
+++ b/app/src/documents/Table/code-views.ts
@@ -1,8 +1,10 @@
 export const WITHOUT_DIVIDERS = `
-<h2>Título de tabla</h2>
-<p className="text-md mt-3">
-  Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
-</p>
+<div class="table-title">
+  <h2 class="mb-4">Título de tabla</h2>
+  <p class="text-md">
+    Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+  </p>
+</div>
 <div class="responsive-scroll" tabIndex="0">
     <table class="table table-borderless">
         <thead>
@@ -132,6 +134,12 @@ export const WITHOUT_DIVIDERS = `
 </div>
 `;
 export const WITH_DIVIDERS = `
+<div class="table-title">
+  <h2 class="mb-4">Título de tabla</h2>
+  <p class="text-md">
+    Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+  </p>
+</div>
 <div class="responsive-scroll" tabIndex="0">
     <table class="table">
         <thead>
@@ -258,6 +266,12 @@ export const WITH_DIVIDERS = `
 </div>
 `;
 export const WITH_ZEBRA = `
+<div class="table-title">
+  <h2 class="mb-4">Título de tabla</h2>
+  <p class="text-md">
+    Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+  </p>
+</div>
 <div class="responsive-scroll" tabIndex="0">
     <table class="table table-striped">
         <thead>
@@ -384,6 +398,12 @@ export const WITH_ZEBRA = `
 </div>
 `;
 export const WITH_CHECKBOX = `
+<div class="table-title">
+  <h2 class="mb-4">Título de tabla</h2>
+  <p class="text-md">
+    Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+  </p>
+</div>
 <div class="responsive-scroll" tabIndex="0">
     <table class="table">
         <thead>
@@ -477,6 +497,12 @@ export const WITH_CHECKBOX = `
 </div>
 `;
 export const TABLE_TEXT = `
+<div class="table-title">
+  <h2 class="mb-4">Título de tabla</h2>
+  <p class="text-md">
+    Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+  </p>
+</div>
 <div class="responsive-scroll" tabIndex="0">
     <table class="table">
         <thead>
@@ -512,6 +538,12 @@ export const TABLE_TEXT = `
 </div>
 `;
 export const TABLE_NUMBER = `
+<div class="table-title">
+  <h2 class="mb-4">Título de tabla</h2>
+  <p class="text-md">
+    Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+  </p>
+</div>
 <div class="responsive-scroll" tabIndex="0">
     <table class="table">
         <thead>
@@ -560,6 +592,12 @@ export const TABLE_NUMBER = `
 </div>
 `;
 export const TABLE_LINK = `
+<div class="table-title">
+  <h2 class="mb-4">Título de tabla</h2>
+  <p class="text-md">
+    Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+  </p>
+</div>
 <div class="responsive-scroll" tabIndex="0">
     <table class="table">
         <thead>
@@ -624,6 +662,12 @@ export const TABLE_LINK = `
 </div>
 `;
 export const TABLE_TAG = `
+<div class="table-title">
+  <h2 class="mb-4">Título de tabla</h2>
+  <p class="text-md">
+    Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+  </p>
+</div>
 <div class="responsive-scroll" tabIndex="0">
     <table class="table">
         <thead>
@@ -672,6 +716,12 @@ export const TABLE_TAG = `
 </div>
 `;
 export const TABLE_BUTTON = `
+<div class="table-title">
+  <h2 class="mb-4">Título de tabla</h2>
+  <p class="text-md">
+    Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+  </p>
+</div>
 <div class="responsive-scroll" tabIndex="0">
     <table class="table">
         <thead>
@@ -728,6 +778,12 @@ export const TABLE_BUTTON = `
 </div>
 `;
 export const TABLE_BUTTON_ICON = `
+<div class="table-title">
+  <h2 class="mb-4">Título de tabla</h2>
+  <p class="text-md">
+    Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+  </p>
+</div>
 <div class="responsive-scroll" tabIndex="0">
     <table class="table">
         <thead>
@@ -839,7 +895,14 @@ export const TABLE_BUTTON_ICON = `
 </div>
 `;
 
-export const TABLE_ACCESSIBILTY = `<div class="responsive-scroll" tabIndex="0">
+export const TABLE_ACCESSIBILTY = `
+<div class="table-title">
+  <h2 class="mb-4">Título de tabla</h2>
+  <p class="text-md">
+    Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+  </p>
+</div>
+<div class="responsive-scroll" tabIndex="0">
     <table class="table table-borderless" aria-describedby="Tabla">
         <thead>
             <tr>

--- a/app/src/documents/Table/code-views.ts
+++ b/app/src/documents/Table/code-views.ts
@@ -1,4 +1,8 @@
 export const WITHOUT_DIVIDERS = `
+<h2>Título de tabla</h2>
+<p className="text-md mt-3">
+  Este es un bloque de texto de descripción de la tabla que puede ocupar hasta 2 líneas de párrafo.
+</p>
 <div class="responsive-scroll" tabIndex="0">
     <table class="table table-borderless">
         <thead>

--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -188,3 +188,7 @@
     outline: none;
   }
 }
+
+.table-title {
+  margin-bottom: 32px;
+}

--- a/src/styles/variables/_typography.scss
+++ b/src/styles/variables/_typography.scss
@@ -23,7 +23,7 @@ $h1-font-weight: $font-weight-bold;
 $h2-font-weight: $font-weight-semibold;
 $h3-font-weight: $font-weight-semibold;
 $h4-font-weight: $font-weight-semibold;
-$h5-font-weight: $font-weight-bold;
+$h5-font-weight: $font-weight-semibold;
 $h6-font-weight: $font-weight-semibold;
 
 $heading-styles: (


### PR DESCRIPTION
Tiene que ver con la card '#S0926  Obelisco | Ajustes de templates'
- Corregir titulares h2 en adelante para que tengan peso tipográfico semibold
- Eliminar referencias a cantidad de caracteres en Contenidos > Redactar una noticia 
- Corregir tipografía en templates ajustados por diseño (falta el figma)

- Titulo y bajada en tablas